### PR TITLE
Fixing cd into non Folder item.

### DIFF
--- a/revelationcli.py
+++ b/revelationcli.py
@@ -400,14 +400,14 @@ class RevelationInteractive(cmd.Cmd, RevelationCli):
             while self.passwords.iter_next(itera):
                 entry = self.passwords.get_value(itera, 2)
                 LOG.debug('- Entry (%s) : %s', entry.typename, entry.name)
-                if entry.name == params:
+                if entry.name == params and entry.typename == 'Folder':
                     self.itera = self.passwords.iter_children(itera)
                     found = True
                     break
                 itera = self.passwords.iter_next(itera)
             entry = self.passwords.get_value(itera, 2)
             LOG.debug('* Entry (%s) : %s', entry.typename, entry.name)
-            if entry.name == params:
+            if entry.name == params and entry.typename == 'Folder':
                 self.itera = self.passwords.iter_children(itera)
                 self.path = '%s/%s' % (self.path, params)
                 found = True


### PR DESCRIPTION
```
(Cmd) ls
  | \_ TestPassword
(Cmd) cd TestPassword
No folder of the name "TestPassword" were found in this folder.
```

Issue: https://github.com/arjunadeltoso/revelationcli/issues/2