### PR TITLE
respect EOF (Ctrl+D) to exit

### DIFF
--- a/revelationcli.py
+++ b/revelationcli.py
@@ -419,6 +419,11 @@ class RevelationInteractive(cmd.Cmd, RevelationCli):
         """ Quit the program. """
         self.do_quit(params)
 
+    def do_EOF(self, params):
+        """ Quit the program. """
+        print('\n')  # since no command was entered, clear the prompt line
+        self.do_quit(params)
+
     def do_ls(self, params):
         """ List directory and password available in the current
         directory.


### PR DESCRIPTION
I have a habit of using Ctrl + D to exit various utilities and wanted that to work in revelation.cli as well.

Thanks for the original program, it helps me out regularly.

Paul